### PR TITLE
Fix possible fix(deps): 7 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/robfig/cron/v3 v3.0.1
-	golang.org/x/crypto v0.41.0
+	golang.org/x/crypto v0.55.0
 	golang.org/x/sys v0.35.0
 	modernc.org/sqlite v1.38.2
 )


### PR DESCRIPTION
Small change to `go.mod` — a scan flagged the code below and it looked genuine. It is around line 1.

CVE-2025-47913 is a real vulnerability in golang.org/x/crypto versions prior to 0.43.0. When an SSH client incorrectly receives an SSH_AGENT_SUCCESS message while expecting another response, it triggers a panic, causing the client process to terminate early. This can be leveraged for denial‑of‑service attacks. The issue is fixed in version 0.43.0, so the currently used version (0.41.0) is vulnerable and should be upgraded.

Update golang.org/x/crypto to v0.55.0 to resolve multiple CVE advisories.

For reference: rule `CVE-2025-47913`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
